### PR TITLE
Adds the option to use custom uri.

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -17,13 +17,14 @@ class Translator {
 	/**
 	 * Initialize DeepL client
 	 *
+         * @param string $customUri
 	 * @param string $authKey
 	 */
-	public function __construct(string $authKey) {
+	public function __construct(string $authKey, string $customUri = null) {
 		$this->authKey = $authKey;
 
 		$this->client = new Client([
-			'base_uri' => self::BASE_URI,
+			'base_uri' => is_null($customUri) ? self::BASE_URI : $customUri,
 			'headers' => [
 				'Accept' => 'application/json',
 				'Content-Type' => 'application/json',


### PR DESCRIPTION
If your using the free api version of deepl.com
you have to use an other domain name like in my case https://api-free.deepl.com/v2/
so with this adjustment you can use another uri